### PR TITLE
Btmkpl postalcodes

### DIFF
--- a/faker/providers/address/dk_DK/__init__.py
+++ b/faker/providers/address/dk_DK/__init__.py
@@ -1,0 +1,8 @@
+# coding=utf-8
+
+from __future__ import unicode_literals
+from .. import Provider as AddressProvider
+
+
+class Provider(AddressProvider):
+    postcode_formats = ('####', )

--- a/faker/providers/address/fr_FR/__init__.py
+++ b/faker/providers/address/fr_FR/__init__.py
@@ -110,6 +110,8 @@ class Provider(AddressProvider):
         ('971', 'Guadeloupe'), ('972', 'Martinique'), ('973', 'Guyane'), ('974', 'La Réunion'), ('976', 'Mayotte')
     )
 
+    postcode_formats = ('#####',)
+
     @classmethod
     def street_prefix(cls):
         """

--- a/faker/providers/address/fr_FR/__init__.py
+++ b/faker/providers/address/fr_FR/__init__.py
@@ -39,7 +39,7 @@ class Provider(AddressProvider):
     )
 
     building_number_formats = ('%', '%#', '%#', '%#', '%##')
-    postcode_formats = ('#####', '## ###')
+    postcode_formats = ('#####', )
     countries = (
         'Afghanistan', 'Afrique du sud', 'Albanie', 'Algérie', 'Allemagne', 'Andorre', 'Angola', 'Anguilla',
         'Antarctique', 'Antigua et Barbuda', 'Antilles néerlandaises', 'Arabie saoudite', 'Argentine', 'Arménie',
@@ -109,8 +109,6 @@ class Provider(AddressProvider):
         ('92', 'Hauts-de-Seine'), ('93', 'Seine-Saint-Denis'), ('94', 'Val-de-Marne'), ('95', "Val-d'Oise"),
         ('971', 'Guadeloupe'), ('972', 'Martinique'), ('973', 'Guyane'), ('974', 'La Réunion'), ('976', 'Mayotte')
     )
-
-    postcode_formats = ('#####',)
 
     @classmethod
     def street_prefix(cls):

--- a/faker/providers/address/fr_LU/__init__.py
+++ b/faker/providers/address/fr_LU/__init__.py
@@ -1,0 +1,8 @@
+# coding=utf-8
+
+from __future__ import unicode_literals
+from .. import Provider as AddressProvider
+
+
+class Provider(AddressProvider):
+    postcode_formats = ('####',)

--- a/faker/providers/address/nl_BE/__init__.py
+++ b/faker/providers/address/nl_BE/__init__.py
@@ -1,0 +1,8 @@
+# coding=utf-8
+
+from __future__ import unicode_literals
+from .. import Provider as AddressProvider
+
+
+class Provider(AddressProvider):
+    postcode_formats = ('####',)

--- a/faker/providers/address/no_NO/__init__.py
+++ b/faker/providers/address/no_NO/__init__.py
@@ -27,11 +27,3 @@ class Provider(AddressProvider):
     address_formats = ['{{street_address}}, {{postcode}} {{city}}', ]
     building_number_formats = ['#', '#', '#', '#?', '##', '##', '##?']
     postcode_formats = ['####', ]
-
-    @classmethod
-    def postcode(cls):
-        """
-        :example 0234
-        """
-        return cls.random_element(cls.postcode_formats)
-

--- a/faker/providers/address/sv_SE/__init__.py
+++ b/faker/providers/address/sv_SE/__init__.py
@@ -24,7 +24,7 @@ class Provider(AddressProvider):
 
     address_formats = ("{{street_address}}\n{{postcode}} {{city}}", )
 
-    postcode_formats = ('#####', )
+    postcode_formats = ('### ##', )
 
     city_formats = ('{{city_name}}', )
 

--- a/faker/tests/dk_DK/__init__.py
+++ b/faker/tests/dk_DK/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+import unittest
+import re
+
+from faker import Factory
+from faker.utils import text
+from .. import string_types
+
+
+class dk_DK_FactoryTestCase(unittest.TestCase):
+    def setUp(self):
+      self.factory = Factory.create('dk_DK')
+
+    def test_postcode(self):
+      postcode  = self.factory.postcode()
+      assert postcode
+      assert isinstance(postcode, string_types)
+      self.assertRegexpMatches(postcode, r'\A\d{4}$')

--- a/faker/tests/fr_FR/__init__.py
+++ b/faker/tests/fr_FR/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+import unittest
+import re
+
+from faker import Factory
+from faker.utils import text
+from .. import string_types
+
+
+class fr_FR_FactoryTestCase(unittest.TestCase):
+    def setUp(self):
+      self.factory = Factory.create('fr_FR')
+
+    def test_postcode(self):
+      postcode  = self.factory.postcode()
+      assert postcode
+      assert isinstance(postcode, string_types)
+      self.assertRegexpMatches(postcode, r'\A\d{5}$')

--- a/faker/tests/fr_FR/__init__.py
+++ b/faker/tests/fr_FR/__init__.py
@@ -17,3 +17,8 @@ class fr_FR_FactoryTestCase(unittest.TestCase):
       assert postcode
       assert isinstance(postcode, string_types)
       self.assertRegexpMatches(postcode, r'\A\d{5}$')
+
+      from faker.providers.address.fr_FR import Provider
+      formats = Provider.postcode_formats
+      assert '### ##' not in formats
+      assert '#####' in formats

--- a/faker/tests/fr_LU/__init__.py
+++ b/faker/tests/fr_LU/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+import unittest
+import re
+
+from faker import Factory
+from faker.utils import text
+from .. import string_types
+
+
+class fr_LU_FactoryTestCase(unittest.TestCase):
+    def setUp(self):
+      self.factory = Factory.create('fr_LU')
+
+    def test_postcode(self):
+      postcode  = self.factory.postcode()
+      assert postcode
+      assert isinstance(postcode, string_types)
+      self.assertRegexpMatches(postcode, r'\A\d{4}$')

--- a/faker/tests/ne_np/__init__.py
+++ b/faker/tests/ne_np/__init__.py
@@ -37,7 +37,12 @@ class ne_NP_FactoryTestCase(unittest.TestCase):
       from faker.providers.person.ne_NP import Provider
       first_names = Provider.first_names
       name = self.factory.name()
-      first_name, last_name = name.split()
+
+      if len(name.split()) == 2:
+          first_name, last_name = name.split()
+      else:
+          prefix, first_name, last_name = name.split()
+
       assert first_name
       assert isinstance(first_name, string_types)
       assert first_name in first_names
@@ -48,4 +53,4 @@ class ne_NP_FactoryTestCase(unittest.TestCase):
       assert last_name in last_names
       
       
-      
+

--- a/faker/tests/nl_BE/__init__.py
+++ b/faker/tests/nl_BE/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+import unittest
+import re
+
+from faker import Factory
+from faker.utils import text
+from .. import string_types
+
+
+class nl_BE_FactoryTestCase(unittest.TestCase):
+    def setUp(self):
+      self.factory = Factory.create('nl_BE')
+
+    def test_postcode(self):
+      postcode  = self.factory.postcode()
+      assert postcode
+      assert isinstance(postcode, string_types)
+      self.assertRegexpMatches(postcode, r'\A\d{4}$')

--- a/faker/tests/no_NO/__init__.py
+++ b/faker/tests/no_NO/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+import unittest
+import re
+
+from faker import Factory
+from faker.utils import text
+from .. import string_types
+
+
+class no_NO_FactoryTestCase(unittest.TestCase):
+    def setUp(self):
+      self.factory = Factory.create('no_NO')
+
+    def test_postcode(self):
+      postcode  = self.factory.postcode()
+      assert postcode
+      assert isinstance(postcode, string_types)
+      self.assertRegexpMatches(postcode, r'\A\d{4}$')


### PR DESCRIPTION
1. Faker is missing postal code generation for some locales. In particular this PR adds postal code formats for the following locales:
   
   ```
   ne_BE: ####
   fr_LU: ####
   dk_DK: ####
   ```
2. The `no_NO` postalcode was being generated as the literal `####`. This existence of the postalcode class method caused this behavior and was unnecessary. I removed the method and added tests.
3. `sv_SE` postalcodes were missing a space in the format which I added. The format is now `### ##`.
4. Do not include a space in French postcodes. (`#####` instead of `### ##`)
5. The tests for the `ne_NP` locale were failing due to not handling logic for 3 part names. I fixed that issue.

@chrissiedeist 
# Notes

There are more locales with missing or wrong postalcodes but we are punting on those for now. I'll triage those issues as they come up into JIRA issues.
