### PR TITLE
BTMKPL - Update postal code providers

### DIFF
--- a/faker/providers/address/de_AT/__init__.py
+++ b/faker/providers/address/de_AT/__init__.py
@@ -1,0 +1,7 @@
+# coding=utf-8
+
+from __future__ import unicode_literals
+from .. import Provider as AddressProvider
+
+class Provider(AddressProvider):
+    postcode_formats = ('####', )

--- a/faker/providers/address/de_CH/__init__.py
+++ b/faker/providers/address/de_CH/__init__.py
@@ -1,0 +1,7 @@
+# coding=utf-8
+
+from __future__ import unicode_literals
+from .. import Provider as AddressProvider
+
+class Provider(AddressProvider):
+    postcode_formats = ('####', )

--- a/faker/providers/address/el_GR/__init__.py
+++ b/faker/providers/address/el_GR/__init__.py
@@ -72,9 +72,6 @@ class Provider(AddressProvider):
     postcode_formats = (
         '### ##',
         '#####',
-        '#####',
-        'ΤΚ ### ##',
-        'ΤΚ #####',
     )
 
     address_formats = (

--- a/faker/tests/de_AT/__init__.py
+++ b/faker/tests/de_AT/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+import unittest
+import re
+
+from faker import Factory
+from faker.utils import text
+from .. import string_types
+
+
+class de_AT_FactoryTestCase(unittest.TestCase):
+    def setUp(self):
+      self.factory = Factory.create('de_AT')
+
+    def test_postcode(self):
+      postcode  = self.factory.postcode()
+      assert postcode
+      assert isinstance(postcode, string_types)
+      self.assertRegexpMatches(postcode, r'\A\d{4}$')

--- a/faker/tests/de_CH/__init__.py
+++ b/faker/tests/de_CH/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+import unittest
+import re
+
+from faker import Factory
+from faker.utils import text
+from .. import string_types
+
+
+class de_CH_FactoryTestCase(unittest.TestCase):
+    def setUp(self):
+      self.factory = Factory.create('de_CH')
+
+    def test_postcode(self):
+      postcode  = self.factory.postcode()
+      assert postcode
+      assert isinstance(postcode, string_types)
+      self.assertRegexpMatches(postcode, r'\A\d{4}$')

--- a/faker/tests/el_GR/__init__.py
+++ b/faker/tests/el_GR/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import unicode_literals
+
+import unittest
+import re
+
+from faker import Factory
+from faker.utils import text
+from .. import string_types
+
+class el_GR_FactoryTestCase(unittest.TestCase):
+    def setUp(self):
+      self.factory = Factory.create('el_GR')
+
+    def test_postcode(self):
+      postcode  = self.factory.postcode()
+      assert postcode
+      assert isinstance(postcode, string_types)
+      self.assertRegexpMatches(postcode, r'\A(\d{3}\s\d{2})|(\d{5})')


### PR DESCRIPTION
- Add `de_AT` postal_code provider with format: ####
- Add `de_CH` postal_code provider with format: ####
- Update `el_GR` postal_code provider: remove TK prefixes as a valid
  postal code.
